### PR TITLE
Make VSCode settings local, keep out of repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 nl.json
+
+# local VSCode config
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
-nl.json
-
 # local VSCode config
 .vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "liveServer.settings.port": 5501
-}


### PR DESCRIPTION
each developer, if using VSCode may want to have their own  settings. Therefore, the config file should be in .gitignore and not committed to the repository.

By the way, is there a reason to keep `nl.json` in `.gitignore`? I can see [there is already a Dutch translation present](https://github.com/theodi/data-ethics-canvas/blob/master/lang/nl.json).

PS: I intend to submit a Portuguese translation when I get some time to do it.

Fixes #8, #9